### PR TITLE
Do not send PhysicalResourceId if Create fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,15 +10,19 @@ exports.FAILED = "FAILED";
  
 exports.send = function(event, context, responseStatus, responseData, physicalResourceId) {
  
-    var responseBody = JSON.stringify({
+    var jsonBody = {
         Status: responseStatus,
         Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
-        PhysicalResourceId: physicalResourceId || context.logStreamName,
         StackId: event.StackId,
         RequestId: event.RequestId,
         LogicalResourceId: event.LogicalResourceId,
         Data: responseData
-    });
+    };
+    if (!(event.RequestType === 'Create' && responseStatus === exports.FAILED)) {
+      jsonBody.PhysicalResourceId = physicalResourceId || context.logStreamName;
+    }
+
+    var responseBody = JSON.stringify(jsonBody);
  
     console.log("Response body:\n", responseBody);
  


### PR DESCRIPTION
If the creation of a resource fails and `PhysicalResourceId` is included in the response the stack will never be updated.  I assume this is because CloudFormation has no previous ID for the resource yet.

S3 happily accepts the request, but CloudFormation will stay in `CREATE_IN_PROGRESS` until it times out.

If PhysicalRequestId is not included in the request the stack moves to `CREATE_FAILED` as expected.
