### PR TITLE
Use event's PhysicalResourceId if provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ exports.send = function(event, context, responseStatus, responseData, physicalRe
     var responseBody = JSON.stringify({
         Status: responseStatus,
         Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
-        PhysicalResourceId: physicalResourceId || context.logStreamName,
+        PhysicalResourceId: physicalResourceId || ((event.ResourceProperties || {}).PhysicalResourceId) || context.logStreamName,
         StackId: event.StackId,
         RequestId: event.RequestId,
         LogicalResourceId: event.LogicalResourceId,


### PR DESCRIPTION
Fixes issue #2.

If no user-provided physical resource ID is found, try to use the CloudFormation-provided physical resource ID, falling back to the mostly random context's log stream name only as last resort. 

This will cause the CloudFormation replace-on-update logic to behave as expected and not "replace" custom resources by deleting them in the update cleanup stage, unless the user really intends it to be so.