### PR TITLE
Add noEcho parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 /* Copyright 2015 Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
    This file is licensed to you under the AWS Customer Agreement (the "License").
    You may not use this file except in compliance with the License.
-   A copy of the License is located at http://aws.amazon.com/agreement/.
+   A copy of the License is located at http://aws.amazon.com/agreement/ .
    This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
    See the License for the specific language governing permissions and limitations under the License. */
- 
+
 exports.SUCCESS = "SUCCESS";
 exports.FAILED = "FAILED";
- 
-exports.send = function(event, context, responseStatus, responseData, physicalResourceId) {
- 
+
+exports.send = function(event, context, responseStatus, responseData, physicalResourceId, noEcho) {
+
     var responseBody = JSON.stringify({
         Status: responseStatus,
         Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
@@ -17,14 +17,15 @@ exports.send = function(event, context, responseStatus, responseData, physicalRe
         StackId: event.StackId,
         RequestId: event.RequestId,
         LogicalResourceId: event.LogicalResourceId,
+        NoEcho: noEcho || false,
         Data: responseData
     });
- 
+
     console.log("Response body:\n", responseBody);
- 
+
     var https = require("https");
     var url = require("url");
- 
+
     var parsedUrl = url.parse(event.ResponseURL);
     var options = {
         hostname: parsedUrl.hostname,
@@ -36,19 +37,18 @@ exports.send = function(event, context, responseStatus, responseData, physicalRe
             "content-length": responseBody.length
         }
     };
- 
+
     var request = https.request(options, function(response) {
         console.log("Status code: " + response.statusCode);
         console.log("Status message: " + response.statusMessage);
         context.done();
     });
- 
+
     request.on("error", function(error) {
         console.log("send(..) failed executing https.request(..): " + error);
         context.done();
     });
- 
+
     request.write(responseBody);
     request.end();
 }
-


### PR DESCRIPTION
This is basically a copy / paste of the `cfn-response` module as it is presented in the AWS User Guide[1] today (11th June, 2018). Notably, AWS has added the `noEcho` parameter.

[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html#cfn-lambda-function-code-cfnresponsemodule